### PR TITLE
Set right permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Flutter plugin to interact with PhotoKit on **iOS**.
 ## Usage
 To use this plugin, add `flutter_photokit` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/)
 
-Then, include the `NSPhotoLibraryAddUsageDescription` permission in your [Info.plist](./example/ios/Runner/Info.plist)
+Then, include the `NSPhotoLibraryUsageDescription` permission in your [Info.plist](./example/ios/Runner/Info.plist)
 
 ### Example
 For an example on how to use this plugin, check out the [sample app](./example/lib/main.dart)


### PR DESCRIPTION
The example app crashed with the current settings. NSPhotoLibraryAddUsageDescription should be NSPhotoLibraryUsageDescription to make it work.